### PR TITLE
Add initial database schema and seed data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+*.db

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ Una fuente de verdad de API y un solo origen en dev para evitar CORS: el fronten
 
 DB simple en dev: SQLite (archivo local). Postgres opcional por DATABASE_URL.
 
+### Base de datos
+
+```bash
+cd backend
+alembic upgrade head
+python -m app.seed
+```
+
 Estabilidad > “último hype”: FastAPI + SQLAlchemy 2 + Alembic + Pydantic v2; React + Vite + TS + Tailwind + shadcn/ui + React Query + react-hook-form + Zod.
 
 Ergonomía: toasts para éxito/error, loaders decentes, tablas con búsqueda/orden/paginación, combobox “creatable”.

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = migrations
+sqlalchemy.url = sqlite:///./goldcert.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,4 @@
+from .database import engine
+from . import models
+
+__all__ = ["engine", "models"]

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,6 @@
+import os
+from sqlalchemy import create_engine
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./goldcert.db")
+
+engine = create_engine(DATABASE_URL, future=True)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from datetime import datetime, date
+from enum import Enum
+
+from sqlalchemy import (
+    Date, DateTime, Enum as SAEnum, ForeignKey, Integer, String, UniqueConstraint
+)
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class RoleEnum(str, Enum):
+    ADMIN = "Admin"
+    ANALISTA = "Analista"
+    CONSULTA = "Consulta"
+
+
+class AmbitoCertificadoEnum(str, Enum):
+    TIPO = "tipo"
+    MARCA = "marca"
+
+
+class EstadoEnum(str, Enum):
+    VIGENTE = "vigente"
+    VENCIDO = "vencido"
+    SUSPENDIDO = "suspendido"
+
+
+class TipoItemEnum(str, Enum):
+    CB = "cb"
+    TEST_REPORT = "test_report"
+    MANUAL = "manual"
+    ETIQUETAS = "etiquetas"
+    MAPA_MODELOS = "mapa_modelos"
+    DECLARACION_IDENTIDAD = "declaracion_identidad"
+    VERIFICACION_IDENTIDAD = "verificacion_identidad"
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    email: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    name: Mapped[str | None] = mapped_column(String, nullable=True)
+    role: Mapped[RoleEnum] = mapped_column(SAEnum(RoleEnum, name="role_enum"), nullable=False)
+    password_hash: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+
+
+class OrganismoCertificacion(Base):
+    __tablename__ = "organismos_certificacion"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    nombre: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    creado_en: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+
+
+class Proveedor(Base):
+    __tablename__ = "proveedores"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    nombre: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    email: Mapped[str | None] = mapped_column(String, nullable=True)
+    telefono: Mapped[str | None] = mapped_column(String, nullable=True)
+    creado_en: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+
+    fabricas: Mapped[list["Fabrica"]] = relationship(back_populates="proveedor")
+    productos: Mapped[list["Producto"]] = relationship(back_populates="proveedor")
+
+
+class Fabrica(Base):
+    __tablename__ = "fabricas"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    proveedor_id: Mapped[int] = mapped_column(ForeignKey("proveedores.id"), nullable=False)
+    nombre: Mapped[str] = mapped_column(String, nullable=False)
+    direccion: Mapped[str | None] = mapped_column(String, nullable=True)
+    audit_valida_desde: Mapped[date | None] = mapped_column(Date, nullable=True)
+    audit_valida_hasta: Mapped[date | None] = mapped_column(Date, nullable=True)
+    creado_en: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+
+    proveedor: Mapped[Proveedor] = relationship(back_populates="fabricas")
+    certificaciones: Mapped[list["Certificacion"]] = relationship(back_populates="fabrica")
+
+
+class Producto(Base):
+    __tablename__ = "productos"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    nombre: Mapped[str] = mapped_column(String, nullable=False)
+    proveedor_id: Mapped[int] = mapped_column(ForeignKey("proveedores.id"), nullable=False)
+    modelo_proveedor: Mapped[str | None] = mapped_column(String, nullable=True)
+    modelo_goldmund: Mapped[str | None] = mapped_column(String, nullable=True)
+    odc_id: Mapped[int | None] = mapped_column(ForeignKey("organismos_certificacion.id"), nullable=True)
+
+    proveedor: Mapped[Proveedor] = relationship(back_populates="productos")
+    certificaciones: Mapped[list["Certificacion"]] = relationship(back_populates="producto")
+
+
+class Certificacion(Base):
+    __tablename__ = "certificaciones"
+    __table_args__ = (
+        UniqueConstraint(
+            "producto_id",
+            "ambito_certificado",
+            "fabrica_id",
+            "valido_desde",
+            "valido_hasta",
+            name="uq_cert_rango_basico",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    producto_id: Mapped[int] = mapped_column(ForeignKey("productos.id"), nullable=False)
+    ambito_certificado: Mapped[AmbitoCertificadoEnum] = mapped_column(
+        SAEnum(AmbitoCertificadoEnum, name="ambito_certificado_enum"), nullable=False, default=AmbitoCertificadoEnum.TIPO
+    )
+    fabrica_id: Mapped[int | None] = mapped_column(ForeignKey("fabricas.id"), nullable=True)
+    valido_desde: Mapped[date] = mapped_column(Date, nullable=False)
+    valido_hasta: Mapped[date] = mapped_column(Date, nullable=False)
+    estado: Mapped[EstadoEnum] = mapped_column(
+        SAEnum(EstadoEnum, name="estado_enum"), nullable=False, default=EstadoEnum.VIGENTE
+    )
+    creado_en: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+
+    producto: Mapped[Producto] = relationship(back_populates="certificaciones")
+    fabrica: Mapped[Fabrica | None] = relationship(back_populates="certificaciones")
+    requisitos: Mapped[list["CertificacionRequisito"]] = relationship(back_populates="certificacion")
+
+
+class CertificacionRequisito(Base):
+    __tablename__ = "certificaciones_requisitos"
+    __table_args__ = (
+        UniqueConstraint("certificacion_id", "tipo_item", name="uq_cert_item_unico"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    certificacion_id: Mapped[int] = mapped_column(ForeignKey("certificaciones.id"), nullable=False)
+    tipo_item: Mapped[TipoItemEnum] = mapped_column(SAEnum(TipoItemEnum, name="tipo_item_enum"), nullable=False)
+    file_path: Mapped[str] = mapped_column(String, nullable=False)
+    filename_original: Mapped[str] = mapped_column(String, nullable=False)
+    uploaded_by: Mapped[str | None] = mapped_column(String, nullable=True)
+    uploaded_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+
+    certificacion: Mapped[Certificacion] = relationship(back_populates="requisitos")

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, date, UTC
+
+from sqlalchemy.orm import Session
+
+from app.database import engine
+from app import models
+
+
+def seed() -> None:
+    with Session(engine) as session:
+        # Admin user
+        if not session.query(models.User).filter_by(email="admin@test.com").first():
+            password_hash = hashlib.sha256("admin".encode()).hexdigest()
+            session.add(
+                models.User(
+                    email="admin@test.com",
+                    name="Admin",
+                    role=models.RoleEnum.ADMIN,
+                    password_hash=password_hash,
+                    created_at=datetime.now(UTC),
+                )
+            )
+
+        # Organismos de certificación
+        for nombre in ["IRAM", "TÜV", "Lenor"]:
+            if not session.query(models.OrganismoCertificacion).filter_by(nombre=nombre).first():
+                session.add(
+                    models.OrganismoCertificacion(
+                        nombre=nombre, creado_en=datetime.now(UTC)
+                    )
+                )
+
+        session.flush()
+
+        # Demo data
+        proveedor = (
+            session.query(models.Proveedor)
+            .filter_by(nombre="Proveedor Demo")
+            .first()
+        )
+        if not proveedor:
+            proveedor = models.Proveedor(
+                nombre="Proveedor Demo",
+                email="proveedor@example.com",
+                telefono="123456",
+                creado_en=datetime.now(UTC),
+            )
+            session.add(proveedor)
+            session.flush()
+
+        fabrica = (
+            session.query(models.Fabrica)
+            .filter_by(nombre="Fabrica Demo", proveedor_id=proveedor.id)
+            .first()
+        )
+        if not fabrica:
+            fabrica = models.Fabrica(
+                proveedor_id=proveedor.id,
+                nombre="Fabrica Demo",
+                direccion="Calle Falsa 123",
+                audit_valida_desde=date(2020, 1, 1),
+                audit_valida_hasta=date(2021, 1, 1),
+                creado_en=datetime.now(UTC),
+            )
+            session.add(fabrica)
+            session.flush()
+
+        producto = (
+            session.query(models.Producto)
+            .filter_by(nombre="Producto Demo")
+            .first()
+        )
+        if not producto:
+            odc = (
+                session.query(models.OrganismoCertificacion)
+                .filter_by(nombre="IRAM")
+                .first()
+            )
+            producto = models.Producto(
+                nombre="Producto Demo",
+                proveedor_id=proveedor.id,
+                modelo_proveedor="P-001",
+                modelo_goldmund="G-001",
+                odc_id=odc.id if odc else None,
+            )
+            session.add(producto)
+            session.flush()
+
+        cert_vigente = (
+            session.query(models.Certificacion)
+            .filter_by(
+                producto_id=producto.id,
+                valido_desde=date(2023, 1, 1),
+                valido_hasta=date(2025, 1, 1),
+            )
+            .first()
+        )
+        if not cert_vigente:
+            cert_vigente = models.Certificacion(
+                producto_id=producto.id,
+                ambito_certificado=models.AmbitoCertificadoEnum.TIPO,
+                fabrica_id=fabrica.id,
+                valido_desde=date(2023, 1, 1),
+                valido_hasta=date(2025, 1, 1),
+                estado=models.EstadoEnum.VIGENTE,
+                creado_en=datetime.now(UTC),
+            )
+            session.add(cert_vigente)
+
+        cert_vencido = (
+            session.query(models.Certificacion)
+            .filter_by(
+                producto_id=producto.id,
+                valido_desde=date(2020, 1, 1),
+                valido_hasta=date(2021, 1, 1),
+            )
+            .first()
+        )
+        if not cert_vencido:
+            cert_vencido = models.Certificacion(
+                producto_id=producto.id,
+                ambito_certificado=models.AmbitoCertificadoEnum.TIPO,
+                fabrica_id=fabrica.id,
+                valido_desde=date(2020, 1, 1),
+                valido_hasta=date(2021, 1, 1),
+                estado=models.EstadoEnum.VENCIDO,
+                creado_en=datetime.now(UTC),
+            )
+            session.add(cert_vencido)
+
+        session.commit()
+
+
+if __name__ == "__main__":
+    seed()

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -1,0 +1,48 @@
+import os
+import sys
+from pathlib import Path
+from logging.config import fileConfig
+
+from sqlalchemy import create_engine
+from alembic import context
+
+# ensure app is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.models import Base
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+def get_url() -> str:
+    return os.getenv("DATABASE_URL", config.get_main_option("sqlalchemy.url"))
+
+def run_migrations_offline() -> None:
+    url = get_url()
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online() -> None:
+    connectable = create_engine(get_url(), future=True)
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/migrations/versions/0001_init.py
+++ b/backend/migrations/versions/0001_init.py
@@ -1,0 +1,134 @@
+"""Initial schema"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0001_init"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    role_enum = sa.Enum("Admin", "Analista", "Consulta", name="role_enum")
+    ambito_enum = sa.Enum("tipo", "marca", name="ambito_certificado_enum")
+    estado_enum = sa.Enum("vigente", "vencido", "suspendido", name="estado_enum")
+    tipo_item_enum = sa.Enum(
+        "cb",
+        "test_report",
+        "manual",
+        "etiquetas",
+        "mapa_modelos",
+        "declaracion_identidad",
+        "verificacion_identidad",
+        name="tipo_item_enum",
+    )
+
+    bind = op.get_bind()
+    for enum in [role_enum, ambito_enum, estado_enum, tipo_item_enum]:
+        enum.create(bind, checkfirst=True)
+
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("email", sa.String, nullable=False, unique=True),
+        sa.Column("name", sa.String, nullable=True),
+        sa.Column("role", role_enum, nullable=False),
+        sa.Column("password_hash", sa.String, nullable=False),
+        sa.Column("created_at", sa.DateTime, nullable=False),
+    )
+
+    op.create_table(
+        "organismos_certificacion",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("nombre", sa.String, nullable=False, unique=True),
+        sa.Column("creado_en", sa.DateTime, nullable=False),
+    )
+
+    op.create_table(
+        "proveedores",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("nombre", sa.String, nullable=False, unique=True),
+        sa.Column("email", sa.String, nullable=True),
+        sa.Column("telefono", sa.String, nullable=True),
+        sa.Column("creado_en", sa.DateTime, nullable=False),
+    )
+
+    op.create_table(
+        "fabricas",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("proveedor_id", sa.Integer, sa.ForeignKey("proveedores.id"), nullable=False),
+        sa.Column("nombre", sa.String, nullable=False),
+        sa.Column("direccion", sa.String, nullable=True),
+        sa.Column("audit_valida_desde", sa.Date, nullable=True),
+        sa.Column("audit_valida_hasta", sa.Date, nullable=True),
+        sa.Column("creado_en", sa.DateTime, nullable=False),
+    )
+
+    op.create_table(
+        "productos",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("nombre", sa.String, nullable=False),
+        sa.Column("proveedor_id", sa.Integer, sa.ForeignKey("proveedores.id"), nullable=False),
+        sa.Column("modelo_proveedor", sa.String, nullable=True),
+        sa.Column("modelo_goldmund", sa.String, nullable=True),
+        sa.Column("odc_id", sa.Integer, sa.ForeignKey("organismos_certificacion.id"), nullable=True),
+    )
+
+    op.create_table(
+        "certificaciones",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("producto_id", sa.Integer, sa.ForeignKey("productos.id"), nullable=False),
+        sa.Column("ambito_certificado", ambito_enum, nullable=False, server_default="tipo"),
+        sa.Column("fabrica_id", sa.Integer, sa.ForeignKey("fabricas.id"), nullable=True),
+        sa.Column("valido_desde", sa.Date, nullable=False),
+        sa.Column("valido_hasta", sa.Date, nullable=False),
+        sa.Column("estado", estado_enum, nullable=False, server_default="vigente"),
+        sa.Column("creado_en", sa.DateTime, nullable=False),
+        sa.UniqueConstraint(
+            "producto_id",
+            "ambito_certificado",
+            "fabrica_id",
+            "valido_desde",
+            "valido_hasta",
+            name="uq_cert_rango_basico",
+        ),
+    )
+
+    op.create_table(
+        "certificaciones_requisitos",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("certificacion_id", sa.Integer, sa.ForeignKey("certificaciones.id"), nullable=False),
+        sa.Column("tipo_item", tipo_item_enum, nullable=False),
+        sa.Column("file_path", sa.String, nullable=False),
+        sa.Column("filename_original", sa.String, nullable=False),
+        sa.Column("uploaded_by", sa.String, nullable=True),
+        sa.Column("uploaded_at", sa.DateTime, nullable=False),
+        sa.UniqueConstraint("certificacion_id", "tipo_item", name="uq_cert_item_unico"),
+    )
+
+def downgrade() -> None:
+    op.drop_table("certificaciones_requisitos")
+    op.drop_table("certificaciones")
+    op.drop_table("productos")
+    op.drop_table("fabricas")
+    op.drop_table("proveedores")
+    op.drop_table("organismos_certificacion")
+    op.drop_table("users")
+
+    bind = op.get_bind()
+    role_enum = sa.Enum("Admin", "Analista", "Consulta", name="role_enum")
+    ambito_enum = sa.Enum("tipo", "marca", name="ambito_certificado_enum")
+    estado_enum = sa.Enum("vigente", "vencido", "suspendido", name="estado_enum")
+    tipo_item_enum = sa.Enum(
+        "cb",
+        "test_report",
+        "manual",
+        "etiquetas",
+        "mapa_modelos",
+        "declaracion_identidad",
+        "verificacion_identidad",
+        name="tipo_item_enum",
+    )
+    for enum in [tipo_item_enum, estado_enum, ambito_enum, role_enum]:
+        enum.drop(bind, checkfirst=True)


### PR DESCRIPTION
## Summary
- define SQLAlchemy models with enums and relationships
- add Alembic migration 0001_init with relational schema
- provide idempotent seed script for admin and demo data

## Testing
- `cd backend && alembic upgrade head`
- `cd backend && python -m app.seed`
- `cd backend && sqlite3 goldcert.db "SELECT * FROM organismos_certificacion;"`
- `cd backend && sqlite3 goldcert.db "SELECT email FROM users;"`


------
https://chatgpt.com/codex/tasks/task_e_689a817f7c68832eb11eced0bf08f72f